### PR TITLE
fix for issue i had when configuring flatten.py

### DIFF
--- a/flatten.py
+++ b/flatten.py
@@ -115,7 +115,7 @@ print "Flattening directory: %s" % (directory)
 for dirpath, dirnames, filenames in os.walk(directory):
     for fileName in filenames:
         outputFile = os.path.join(dirpath, fileName)
-        if dirpath == directory:
+        if dirpath == destination:
             continue
         target = os.path.join(destination, fileName)
         try:


### PR DESCRIPTION
Not 100% sure what the intent of this move-file-loop continue statement is but I was having an issue when configuring flatten.py in nzbget where my files were not getting moved to the folder I set in the DestinationDirectory setting.